### PR TITLE
Use xmltodict instead of ElementTree

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+xmltodict = "*"
+requests = "*"
+pymsteams = "*"
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,72 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "557f00756f01cd45906ccb030c7799915170d9b1d32fba756375eb5c35b372f8"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
+                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
+            ],
+            "version": "==2020.4.5.1"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
+                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+            ],
+            "version": "==2.9"
+        },
+        "pymsteams": {
+            "hashes": [
+                "sha256:db94a0d94f3039ee4ccd1082be2a033f780ef1d8e37342655a57c3812f9788e2"
+            ],
+            "index": "pypi",
+            "version": "==0.1.12"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
+                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
+            ],
+            "index": "pypi",
+            "version": "==2.23.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
+                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
+            ],
+            "version": "==1.25.9"
+        },
+        "xmltodict": {
+            "hashes": [
+                "sha256:50d8c638ed7ecb88d90561beedbf720c9b4e851a9fa6c47ebd64e99d166d8a21",
+                "sha256:8bbcb45cc982f48b2ca8fe7e7827c5d792f217ecf1792626f808bf41c3b86051"
+            ],
+            "index": "pypi",
+            "version": "==0.12.0"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # TucowsRSStoTeams
+
 Script to post from Tucows scheduled maintenance RSS to Microsoft Teams
 
-All credit to be directed at https://github.com/LucyGoosey/
+# Setup
+
+Run `pip install -r requirements.txt`
+
+# Acknowledgments
+
+All credit to be directed at [LucyGoosey](https://github.com/LucyGoosey/)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+certifi==2020.4.5.1
+chardet==3.0.4
+idna==2.9
+pymsteams==0.1.12
+requests==2.23.0
+urllib3==1.25.9
+xmltodict==0.12.0


### PR DESCRIPTION
ElementTree is awkward to navigate, due to having to dig into the tag
variable of each item in order to discover the blocks' tag. Navigating
the XML as a dictionary is much more natural and readable.

I've also refactored the code to have a more logical separation, which
should make it easier to read/maintain in the future.